### PR TITLE
Functions for Mapped objects, enhance Get-IdoitObject with filter…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Enhancements
+- New-IdoitMappedObject
+- Get-IdoitMappedObjectFromTemplate
+
 ### v0.4.0
 - New feature: Mapped objects
 - Standardize ObjId, TypeId properties in objects

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -21,6 +21,14 @@ branches:
     increment: Patch
     regex: (hot)?fix(es)?[\/-]
     source-branches: ['master']
+  preview:
+    regex: ^preview$
+    tag: preview
+    increment: Patch
+    source-branches: ['main']
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 500
 
 ignore:
   sha: []

--- a/src/Public/Get-IdoItObjectTypeCategory.ps1
+++ b/src/Public/Get-IdoItObjectTypeCategory.ps1
@@ -52,7 +52,7 @@ Function Get-IdoItObjectTypeCategory {
             'ObjectId' {
                 # if we have an object id, we need to get the type first
                 $obj = Get-IdoItObject -ObjId $ObjId
-                $TypeId = $obj.objecttype
+                $TypeId = $obj.TypeId
             }
             'ObjectType' {
                 # do nothing, type is already set

--- a/src/Public/Get-IdoitMappedObjectFromTemplate.ps1
+++ b/src/Public/Get-IdoitMappedObjectFromTemplate.ps1
@@ -1,0 +1,49 @@
+function Get-IdoitMappedObjectFromTemplate {
+    <#
+    .SYNOPSIS
+        Retrieves a mapped object constructed from a registered Idoit category mapping.
+
+    .DESCRIPTION
+        This function retrieves a mapping of Idoit categories by name and constructs a PSObject based on the registered mapping.
+        It checks if the mapping exists in the global script variable `$Script:IdoitCategoryMaps`.
+        The returned object will have properties defined in the mapping with 'PSProperty' key, which can be used to create or update Idoit objects.
+
+    .PARAMETER MappingName
+        The name of the mapping to retrieve.
+
+    .EXAMPLE
+        Get-IdoitMappedObjectFromTemplate -MappingName 'MyMapping'
+        Retrieves the mapping for 'MyMapping' and constructs a PSObject based on the registered mapping.
+
+    .NOTES
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('Name')]
+        [string] $MappingName
+    )
+    begin {
+        if ($null -eq $Script:IdoitCategoryMaps -or -not $Script:IdoitCategoryMaps.ContainsKey($MappingName)) {
+            Write-Error "No category map registered for name '$MappingName'. Use Register-IdoitCategoryMap to register a mapping." -ErrorAction Stop
+        }
+        $PropertyMap = $Script:IdoitCategoryMaps[$MappingName]
+    }
+    process {
+        $obj = [PSCustomObject]@{}
+        foreach ($cat in $PropertyMap.Mapping) {
+            foreach ($prop in $cat.PropertyList) {
+                $psProp = $prop.PSProperty
+                if ($null -ne $psProp) {
+                    $obj | Add-Member -MemberType NoteProperty -Name $psProp -Value $null -Force
+                }
+            }
+        }
+        $obj | Add-Member -MemberType NoteProperty -Name 'objId' -Value $null -Force
+        return $obj
+    }
+    end {
+        # No cleanup needed
+    }
+}

--- a/src/Public/Get-IdoitObject.ps1
+++ b/src/Public/Get-IdoitObject.ps1
@@ -1,35 +1,125 @@
 function Get-IdoitObject {
     <#
-      .SYNOPSIS
-      Get-IdoitObject returns an object from the i-doit API or $null.
+        .SYNOPSIS
+        Get-IdoitObject returns an object from the i-doit API or $null.
 
-      .DESCRIPTION
-      Get-IdoitObject returns an object or $null.
+        .DESCRIPTION
+        Get-IdoitObject returns an object(s) or $null.
+        It allows to filter by ObjId, ObjectType, Title, TypeTitle and Status.
+        Additionally, it can return categories of the object(s) found.
+        If just a single object id is given, it will use the 'cmdb.object.read' method (returing just the basic object data).
+        if multiple objects or filters are given, it will use the 'cmdb.objects.read' method (returning an array of objects).
 
-      .EXAMPLE
-      Get-IdoitObject -ObjId 540
+        .PARAMETER ObjId
+        The id of the object you want to retrieve from the i-doit API.
+        Single object requests are done by using the 'cmdb.object.read' method.
+        An array will use the "filter" variante of this function.
 
-      .PARAMETER ObjId
-       The id of the object you want to retrieve from the i-doit API.
+        .PARAMETER ObjectType
+        An array of types of the object you want to retrieve from the i-doit API. By name or by id.
+
+        .PARAMETER Title
+        The title of the object you want to retrieve from the i-doit API. This is a string, not an array.
+
+        .PARAMETER TypeTitle
+        The type title of the object you want to retrieve from the i-doit API. This is a string, not an array.
+
+        .PARAMETER Status
+        The status of the object you want to retrieve from the i-doit API. This is a string, not an array.
+
+        .PARAMETER Limit
+        The maximum number of objects to return. This is useful for filtering large result sets.
+
+        .PARAMETER Category
+        An array of categories that should be returned for each object found. This is useful to get additional information about the objects.
+        Each category is returned in a seperate property of the object.
+
+        .EXAMPLE
+        Get-IdoitObject -ObjId 540
+
+        .EXAMPLE
+        Get-IdoitObject -ObjectType 'C__OBJTYPE__PERSON'
+
+        .EXAMPLE
+        Get-IdoitObject -Title 'Server 540'
+
+        .EXAMPLE
+        Get-IdoitObject -ObjectType 'C__OBJTYPE__PERSON' -Category 'C__CATG__GLOBAL', 'C__CATS__PERSON_MASTER' -Limit 2
+        This will return the first two person objects including the categories 'C__CATG__GLOBAL' and 'C__CATS__PERSON_MASTER' each as a separate property.
+
+        .NOTES
+        If you request a single object by ObjId and the object is not found, an error will be thrown.
+        If you request multiple objects or use filters, the function will return an empty array if no objects are found.
       #>
     [cmdletBinding(ConfirmImpact = 'Low')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         # [Alias('Id')]
-        [int] $ObjId
+        [int[]] $ObjId, # List of object IDs to retrieve
+
+        [string[]] $ObjectType, # List of object types
+
+        [string] $Title, # The API allows only one title, so we use a string here
+
+        [Alias('Type_Title')]
+        [string] $TypeTitle, # The API allows only one type title, so we use a string here
+
+        [ValidateSet('C__RECORD_STATUS__BIRTH', 'C__RECORD_STATUS__NORMAL', 'C__RECORD_STATUS__ARCHIVED', 'C__RECORD_STATUS__DELETED', 'C__RECORD_STATUS__TEMPLATE', 'C__RECORD_STATUS__MASS_CHANGES_TEMPLATE')]
+        [string] $Status,
+
+        [int] $Limit, # Limit the number of objects returned
+
+        [string[]] $Category        # List of categories that should be returned for each object found
     )
 
     process {
-        $apiResult = Invoke-Idoit -Method 'cmdb.object.read' -Params @{ id = $ObjId }
-        if ($null -eq $apiResult.id) {          # is it a null array?
-            Write-Error -Message "Object not found Id=$ObjId"
+        # first check, if it is a single object and no filter and category is set
+        if ($ObjId.Count -eq 1 -and $PSBoundParameters.Keys -notin @('ObjectType', 'Title', 'TypeTitle', 'Status', 'Limit', 'Category')) {
+            # this is a single object request, so we can use the 'cmdb.object.read' method
+            $params = @{ id = $ObjId[0] }
+            $apiResult = Invoke-Idoit -Method 'cmdb.object.read' -Params $params
+            if ($null -eq $apiResult.id) {
+                # is it a null object?
+                Write-Error -Message "Object not found with ID $($ObjId[0])." -Category ObjectNotFound
+                return
+            }
+            $apiResult.PSObject.TypeNames.Insert(0, 'Idoit.Object')
+            $apiResult | Add-Member -MemberType NoteProperty -Name 'ObjId' -Value $apiResult.Id -Force
+            $apiResult | Add-Member -MemberType NoteProperty -Name 'TypeId' -Value $apiResult.objecttype -Force
+            # I don't like it. But to stay compatible with 'cmdb.objects.read' we have to add it as objecttype as well.
+            $apiResult | Add-Member -MemberType NoteProperty -Name 'type' -Value $apiResult.objecttype -Force
+            Write-Output $apiResult
             return
         }
-        $apiResult.PSObject.TypeNames.Insert(0, 'Idoit.Object')
-        $apiResult | Add-Member -MemberType NoteProperty -Name 'ObjId' -Value $ObjId -Force
-        $apiResult
+
+        # this is the way to filter objects by several parameters
+        $params = @{ filter = @{} }
+        if ($PSBoundParameters.ContainsKey('Limit')) { $params.limit = $Limit }
+        if ($PSBoundParameters.ContainsKey('Category')) {
+            $params.categories = @($Category)           # categories we want to retrieve are always an array
+        }
+
+        # add filters
+        if ($ObjId.Count -gt 0) { $params.filter += @{ ids = @($ObjId) } }
+        if ($ObjectType.Count -gt 0) { $params.filter += @{ type = @($ObjectType) } }
+        if ($Title) { $params.filter += @{ title = $Title } }
+        if ($TypeTitle) { $params.filter += @{ type_title = $TypeTitle } }
+        if ($Status) { $params.filter += @{ status = $Status } }
+
+        $apiResult = Invoke-Idoit -Method 'cmdb.objects.read' -Params $params
+        if ($null -eq $apiResult.id) {
+            # is it a null array?
+            return
+        }
+        foreach ($obj in $apiResult) {
+            $obj.PSObject.TypeNames.Insert(0, 'Idoit.Object')
+            $obj | Add-Member -MemberType NoteProperty -Name 'ObjId' -Value $obj.Id -Force
+            $obj | Add-Member -MemberType NoteProperty -Name 'TypeId' -Value $obj.type -Force
+            # I don't like it. But to stay compatible with 'cmdb.object.read' we have to add it as objecttype as well.
+            $obj | Add-Member -MemberType NoteProperty -Name 'objecttype' -Value $obj.type -Force
+            $obj
+        }
     }
 }
 

--- a/src/Public/New-IdoitMappedObject.ps1
+++ b/src/Public/New-IdoitMappedObject.ps1
@@ -1,0 +1,81 @@
+function New-IdoitMappedObject {
+    <#
+    .SYNOPSIS
+    Creates a new Idoit object based on the specified mapping.
+
+    .DESCRIPTION
+    This function creates a new Idoit object of the type specified in the mapping.
+    It uses the provided input object to set the properties of the new object according to the mapping.
+    The mapping must be registered using `Register-IdoitCategoryMap` before calling this function.
+
+    .PARAMETER InputObject
+    The input object containing the properties to be set on the new Idoit object.
+    This object should match the structure defined in the mapping.
+
+    .PARAMETER MappingName
+    The name of the mapping to use for creating the new Idoit object.
+
+    .PARAMETER IncludeProperty
+    An array of property names to include when creating the new object.
+    This is useful, if properties are set only on creation and not on update.
+    attributes/properties which are defined as updatetable in the mapping will be set, even if not included here.
+
+    .PARAMETER ExcludeProperty
+    An array of property names to exclude when creating the new object.
+    This is useful, if you want to skip certain properties that are not relevant for the new object.
+
+    .EXAMPLE
+    New-IdoitMappedObject -InputObject $inputObject -MappingName 'MyMapping' -IncludeProperty 'Name', 'Description' -ExcludeProperty 'Tags'
+    Creates a new Idoit object using the specified mapping, including only the 'Name' and 'Description' properties,
+    and excluding the 'Tags' property from the input object.
+
+    .NOTES
+    This function requires the mapping to be registered using `Register-IdoitCategoryMap`.
+
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '', Justification = 'ShouldProcess is handled in called functions.')]
+    param (
+        [Parameter(Mandatory = $true)]
+        [PSObject] $InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias('Name')]
+        [string] $MappingName,
+
+        [string[]] $IncludeProperty,
+
+        [string[]] $ExcludeProperty
+    )
+
+    begin {
+        # check if mapping exists
+        if (-not $Script:IdoitCategoryMaps.ContainsKey($MappingName)) {
+            throw "No category map registered for name '$MappingName'. Use Register-IdoitCategoryMap to register a mapping."
+        }
+        $mapping = $Script:IdoitCategoryMaps[$MappingName]
+    }
+
+    process {
+        $newobj = New-IdoitObject -Name "new($($mapping.IdoitObjectType)-$(New-GUID))" -ObjectType $mapping.IdoitObjectType
+        if ($null -eq $newobj) {
+            throw "Failed to create a new Idoit object of type '$($mapping.IdoitObjectType)'."
+        }
+        # even for attributes that are read-only, we have to set them, otherwise the object will not be created correctly
+        $splatSetMappedObject = @{
+            InputObject = $InputObject
+            ObjId       = $newobj.objId
+            MappingName = $MappingName
+            IncludeProperty = $IncludeProperty
+            ExcludeProperty = $ExcludeProperty
+        }
+        $InputObject.objId = $newobj.objId
+        $ret = Set-IdoitMappedObject @splatSetMappedObject
+        $ret
+    }
+
+    end {
+
+    }
+}

--- a/src/Public/New-IdoitObject.ps1
+++ b/src/Public/New-IdoitObject.ps1
@@ -59,7 +59,7 @@ function New-IdoitObject {
 
         [Parameter( ValueFromPipelineByPropertyName = $True)]
         [ValidateNotNullOrEmpty()]
-        [Alias( 'cmbd_status')]
+        [Alias( 'cmdb_status')]
         [string] $Status,
 
         [Parameter( ValueFromPipelineByPropertyName = $True)]

--- a/src/Public/Search-IdoitObject.ps1
+++ b/src/Public/Search-IdoitObject.ps1
@@ -90,7 +90,7 @@ function Search-IdoItObject {
                 }
             }
         } catch {
-            Throw "Failed to execute the search: $_"
+            Write-Error "Failed to execute the search: $_"
         }
     }
 }

--- a/src/Public/Set-IdoItMappedObject.ps1
+++ b/src/Public/Set-IdoItMappedObject.ps1
@@ -124,8 +124,7 @@ function Set-IdoitMappedObject {
                 }
                 $catValues = Get-IdoItCategory -ObjId $obj.Id -Category $thisMapping.Category
                 if ($null -eq $catValues) {
-                    Write-Warning "No categories found for object type $($thisMapping.Category)($($obj.Objecttype))"
-                    continue
+                    Write-Verbose "No categories found for object type $($thisMapping.Category)($($obj.Objecttype)); Should be new"
                 }
                 # if no action is defined, add the property. If the corresponding catvalue holds an array, the property is added as an array
                 # TODO: Multivalue categories are not supported yet

--- a/tests/Integration/Get-IdoitObject.Tests.ps1
+++ b/tests/Integration/Get-IdoitObject.Tests.ps1
@@ -1,0 +1,108 @@
+BeforeDiscovery {
+    $isNotConnected = $false
+    if ([string]::IsNullOrEmpty($uri) -or [string]::IsNullOrEmpty($apikey) -or $null -eq $credIdoit) {
+        Write-Warning -Message "You need to set the variables `$uri`, `$apikey`, and `$credIdoit` before running the tests."
+        $isNotConnected = $true
+    }
+}
+BeforeAll {
+    $script:ModuleName = 'PSIdoitNG'
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $script:moduleName -Force
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+
+    $testRoot = Join-Path -Path (Get-SamplerAbsolutePath) -ChildPath 'tests'
+    $testHelpersPath = Join-Path -Path $testRoot -ChildPath 'Unit\Helpers'
+    if (-not $IsNotConnected) {
+        Connect-Idoit -Uri $uri -Credential $credIdoit -ApiKey (ConvertFrom-SecureString $apikey -AsPlainText)
+    }
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Disconnect-Idoit -ErrorAction SilentlyContinue
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Integration Get-IdoitObject' -Tag 'Integration' -Skip:$isNotConnected {
+    It 'Filter by ObjectType' -Foreach @(
+        @{ Case = 'ByNumber'; ObjectType = 53 }
+        @{ Case = 'ByString'; ObjectType = 'C__OBJTYPE__PERSON' }
+    ) {
+        $ret = Get-IdoitObject -ObjectType $ObjectType
+        ($ret | Measure-Object).Count | Should -BeGreaterThan 0
+        $ret[0].Type_Title | Should -Be 'Persons'
+    }
+    It 'Filter by ObjectType title' {
+        $ret = Get-IdoitObject -TypeTitle 'Persons'
+        ($ret | Measure-Object).Count | Should -BeGreaterThan 0
+        $ret[0].Type_Title | Should -Be 'Persons'
+    }
+    Context 'Person prefiltered by ObjectType' {
+        BeforeAll {
+            $allPersons = Get-IdoitObject -ObjectType 'C__OBJTYPE__PERSON'
+        }
+        It 'Filter by Title' {
+            $ret = Get-IdoitObject -Title $allPersons[0].Title
+            ($ret | Measure-Object).Count | Should -Be 1
+            $ret[0].Title | Should -Be $allPersons[0].Title
+            $ret[0].Type_Title | Should -Be 'Persons'
+            $ret[0].TypeId | Should -Be 53
+            $ret[0].ObjId | Should -Be $allPersons[0].ObjId
+        }
+        It 'Filter by Type_Title' {
+            $ret = Get-IdoitObject -TypeTitle 'Persons'
+            ($ret | Measure-Object).Count | Should -BeGreaterThan 0
+            $ret[0].Type_Title | Should -Be 'Persons'
+        }
+        It 'Filter by ObjId' {
+            $ret = Get-IdoitObject -ObjId $allPersons[0].ObjId
+            ($ret | Measure-Object).Count | Should -Be 1
+            $ret.ObjId | Should -Be $allPersons[0].ObjId
+            $ret.TypeId | Should -Be 53
+            $ret.objecttype | Should -Be 53     # objecttype is returned as well for compatibility with 'cmdb.objects.read'
+            $ret.type | Should -Be 53           # type is returned as well for compatibility with 'cmdb.object.read'
+            $ret.PSObject.TypeNames | Should -Contain 'Idoit.Object'
+        }
+        It 'Filter by multiple ObjIds' {
+            $ret = Get-IdoitObject -ObjId $allPersons[0].ObjId, $allPersons[1].ObjId
+
+            ($ret | Measure-Object).Count | Should -Be 2
+            $ret[0].ObjId | Should -Be $allPersons[0].ObjId
+            $ret[1].ObjId | Should -Be $allPersons[1].ObjId
+            $ret[0].TypeId | Should -Be 53
+            $ret[1].TypeId | Should -Be 53
+        }
+        It 'Filter by Status' {
+            $ret = Get-IdoitObject -Status 'C__RECORD_STATUS__NORMAL'
+            ($ret | Measure-Object).Count | Should -BeGreaterThan 0
+            $ret[0].cmdb_status | Should -Be 6
+            $ret[0].cmdb_status_title | Should -Be 'in operation'       # funny: the returned status does not contain the property we searched for, but the title should be correct
+        }
+        It 'Filter by StatusId' {
+            foreach ($status in ('C__RECORD_STATUS__BIRTH', 'C__RECORD_STATUS__NORMAL', 'C__RECORD_STATUS__ARCHIVED', 'C__RECORD_STATUS__DELETED', 'C__RECORD_STATUS__TEMPLATE', 'C__RECORD_STATUS__MASS_CHANGES_TEMPLATE')) {
+                # for now we only test that the function returns something, not the actual status
+                # to make this more robust, we would need to create a test object with each status
+                $null = Get-IdoitObject -Status $status
+            }
+        }
+    }
+    Context 'Should return categories with the object' {
+        It 'filter 2 persons by type and return categories' {
+            $ret = Get-IdoitObject -ObjectType 'C__OBJTYPE__PERSON' -Category 'C__CATG__GLOBAL','C__CATS__PERSON_MASTER' -Limit 2
+            ($ret | Measure-Object).Count | Should -Be 2
+            $ret[0].Categories | Should -Not -BeNullOrEmpty
+            $ret[1].Categories | Should -Not -BeNullOrEmpty
+            $ret[0].Categories.C__CATG__GLOBAL | Should -Not -BeNullOrEmpty
+            $ret[1].Categories.C__CATG__GLOBAL | Should -Not -BeNullOrEmpty
+            $ret[1].Categories.C__CATS__PERSON_MASTER | Should -Not -BeNullOrEmpty
+            $ret[0].Categories.C__CATS__PERSON_MASTER | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Helpers/MockData_Cmdb_objects_read.ps1
+++ b/tests/Unit/Helpers/MockData_Cmdb_objects_read.ps1
@@ -1,0 +1,169 @@
+Mock Invoke-RestMethod -ModuleName PSIdoitNG -MockWith {
+    # check request values: All properties in the simulated request param (except apikey) should be in the request
+    # returns the simulated response with the same id as the request
+    # this one is differnt to the standard procedure
+    #   1. we took the same data as in the MockData_Cmdb_object_read.ps1 -> but objecttype is returned as type here by the API
+    #   2. for filtering, we just use the response data (normally the request data would be checked)
+    $body = $body | ConvertFrom-Json
+    # starting with all possible resources, then filtering by the request parameters
+    $thisIdoitObject = $MockData_Cmdb_objects_read
+    if ($null -ne $body.params.filter.ids) {
+        $thisIdoitObject = $thisIdoitObject | Where-Object { $_.Response.result.id -in $body.params.filter.ids }
+    }
+    if ($null -ne $body.params.filter.type) {
+        # C__OBJTYPE__PERSON, the mocked data has a type of 53 for persons
+        if ($body.params.filter.type -eq 'C__OBJTYPE__PERSON') {
+            $thisIdoitObject = $thisIdoitObject | Where-Object { $_.Response.result.type_title -eq 'Persons' }
+        } else {
+            $thisIdoitObject = $thisIdoitObject | Where-Object { $_.Response.result.type -in $body.params.filter.type }
+        }
+    }
+    if ($null -ne $body.params.filter.title) {
+        $thisIdoitObject = $thisIdoitObject | Where-Object { $_.Response.result.title -eq $body.params.filter.title }
+    }
+    if ($null -ne $body.params.filter.type_title) {
+        $thisIdoitObject = $thisIdoitObject | Where-Object { $_.Response.result.type_title -eq $body.params.filter.type_title }
+    }
+    if ($null -ne $body.params.filter.status) {
+        $thisIdoitObject = $thisIdoitObject | Where-Object { $_.Response.result.status -eq $body.params.filter.status }
+    }
+    if ($null -ne $body.params.filter.categories) {
+        $thisIdoitObject = $thisIdoitObject | Where-Object { $_.Response.result.categories -contains $body.params.filter.categories }
+    }
+    if ($null -ne $thisIdoitObject) {
+        [PSCustomObject] @{         # empty list
+            id      = $body.id;
+            jsonrpc = '2.0';
+            result  = @($thisIdoitObject.Response.Result)       # objectreadS returns an array of objects
+        }
+    } else {
+        [PSCustomObject] @{         # empty list
+            id      = $body.id;
+            jsonrpc = '2.0';
+            result  = [PSCustomObject] @{}
+        }
+    }
+} -ParameterFilter {
+    (($body | ConvertFrom-Json).method) -eq 'cmdb.objects.read'
+}
+
+$MockData_Cmdb_objects_read = @(
+    # region persons
+    [PSCustomObject] @{
+        Endpoint = 'cmdb.objects.read';
+        Request  = [PSCustomObject]@{
+            method = 'cmdb.objects.read'; id = '9e2a082e-66a2-42b7-b055-61d99266f9a4'; version = '2.0';
+            params = [PSCustomObject] @{
+                id = 37
+            }
+        };
+        Response = [PSCustomObject]@{
+            id      = '{0}';
+            jsonrpc = '2.0';
+            result  = [PSCustomObject] @{
+                id                = 37;
+                title             = 'Wolfgang Wagner';
+                sysid             = 'SYSID_1733071461';
+                type              = 53;                         # objectS.read returns type (not objecttype)
+                type_title        = 'Persons';
+                type_icon         = '/cmdb/object-type/image/53';
+                status            = 2;
+                cmdb_status       = 6;
+                cmdb_status_title = 'in operation';
+                created           = '2024-10-09 12:56:39';
+                updated           = '2025-05-11 23:10:17';
+                image             = '/cmdb/object/image/37'
+            }
+        };
+        Time     = '2025-05-12 18:08:13'
+    }
+    [PSCustomObject] @{
+        Endpoint = 'cmdb.objects.read';
+        Request  = [PSCustomObject] @{ method = 'cmdb.objects.read'; id = '76b013a7-047f-4793-9356-33a761bed501'; version = '2.0'; params = [PSCustomObject] @{
+                id = 28
+            }
+        };
+        Response = [PSCustomObject]@{
+            id      = '{0}';
+            jsonrpc = '2.0';
+            result  = [PSCustomObject] @{
+                id                = 28;
+                title             = 'User P';
+                sysid             = 'SYSID_1728465262';
+                type        = 53;
+                type_title        = 'Persons';
+                type_icon         = '/cmdb/object-type/image/53';
+                status            = 2;
+                cmdb_status       = 6;
+                cmdb_status_title = 'in operation';
+                created           = '2024-10-09 11:13:54';
+                updated           = '2025-05-11 23:10:09';
+                image             = '/cmdb/object/image/28'
+            }
+        };
+        Time     = '2025-05-12 18:09:33'
+    }
+    #endregion persons
+
+    #region server540
+    [PSCustomObject] @{
+        Endpoint = 'cmdb.objects.read';
+        Request  = [PSCustomObject] @{ method = 'cmdb.objects.read'; id = '4a18bed9-6b9a-4725-a979-943ef85da4eb'; version = '2.0'; params = [PSCustomObject] @{
+                id = 540
+            }
+        };
+        Response = [PSCustomObject]@{
+            id      = '4a18bed9-6b9a-4725-a979-943ef85da4eb';
+            jsonrpc = '2.0';
+            result  = [PSCustomObject] @{
+                id                = 540;
+                title             = 'server540';
+                sysid             = 'SYSID_1730365404';
+                type        = 5;
+                type_title        = 'Server';
+                type_icon         = '/cmdb/object-type/image/5';
+                status            = 2;
+                cmdb_status       = 6;
+                cmdb_status_title = 'in operation';
+                created           = '2024-10-31 09:54:24';
+                updated           = '2025-05-04 18:18:12';
+                image             = '/cmdb/object/image/540'
+            }
+        };
+        Time     = '2025-05-12 18:32:11'
+    }
+    #endregion server540
+    #region CustomObject 4675
+    [PSCustomObject] @{
+        Endpoint = 'cmdb.objects.read';
+        Request  = [PSCustomObject] @{
+            params  = [PSCustomObject] @{
+                id     = 4675;
+                apikey = '***'
+            };
+            version = '2.0';
+            id      = '84df30b0-2b77-466f-bd4e-a29411940b83';
+            method  = 'cmdb.objects.read'
+        };
+        Response = [PSCustomObject] @{
+            id      = '84df30b0-2b77-466f-bd4e-a29411940b83';
+            jsonrpc = '2.0';
+            result  = [PSCustomObject] @{
+                id                = 4675;
+                title             = '042_eServicPortal_Housekeeper';
+                sysid             = 'SYSID_1734102557';
+                type        = 93;
+                type_title        = 'Komponente';
+                type_icon         = '/cmdb/object-type/image/93';
+                status            = 2;
+                cmdb_status       = 6;
+                cmdb_status_title = 'in operation';
+                created           = '2024-12-21 18:14:51';
+                updated           = '2025-05-15 16:32:15';
+                image             = '/cmdb/object/image/4675'
+            }
+        };
+        Time     = '2025-05-29 10:46:31'
+    }
+    #endregion CustomObject 4675
+)

--- a/tests/Unit/Helpers/MockData_cmdb_object_type_categories_read.ps1
+++ b/tests/Unit/Helpers/MockData_cmdb_object_type_categories_read.ps1
@@ -2,7 +2,7 @@ Mock Invoke-RestMethod -ModuleName PSIdoitNG -MockWith {
     # returns the simulated response with the same id as the request
     # in this case, we only can search for the type id (not the name)
     $body = $body | ConvertFrom-Json
-    $thisIdoitObject = $MockData_Cmbd_type_categories_read | Where-Object { $_.Request.params.type -eq $body.params.type }
+    $thisIdoitObject = $MockData_cmdb_type_categories_read | Where-Object { $_.Request.params.type -eq $body.params.type }
     if ($null -ne $thisIdoitObject) {
         $thisIdoitObject.Response.id = $body.id
         $thisIdoitObject.Response
@@ -21,7 +21,7 @@ Mock Invoke-RestMethod -ModuleName PSIdoitNG -MockWith {
     (($body | ConvertFrom-Json).method) -eq 'cmdb.object_type_categories.read'
 }
 
-$MockData_Cmbd_type_categories_read = @(
+$MockData_cmdb_type_categories_read = @(
     [PSCustomObject] @{
         Endpoint = 'cmdb.object_type_categories.read';
         Request  = [PSCustomObject] @{

--- a/tests/Unit/Public/Get-IdoitMappedObjectFromTemplate.tests.ps1
+++ b/tests/Unit/Public/Get-IdoitMappedObjectFromTemplate.tests.ps1
@@ -1,0 +1,47 @@
+# Simple test for Get-IdoitMappedObjectFromTemplate
+BeforeAll {
+    $script:ModuleName = 'PSIdoitNG'
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $script:moduleName -Force
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+
+    $testRoot = Join-Path -Path (Get-SamplerAbsolutePath) -ChildPath 'tests'
+    $testHelpersPath = Join-Path -Path $testRoot -ChildPath 'Unit\Helpers'
+}
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Get-IdoitMappedObjectFromTemplate' {
+    BeforeEach {
+        InModuleScope -ModuleName $script:moduleName {
+            $Script:IdoitCategoryMaps = @{}
+        }
+    }
+    #add test
+    It 'Returns a PSObject with properties from YAML mapping (DemoComponent)' {
+        $yamlPath = Join-Path $testHelpersPath 'ObjectWithCustomCatageory.yaml'
+        Register-IdoitCategoryMap -Path $yamlPath -Force
+
+        $result = Get-IdoitMappedObjectFromTemplate -MappingName 'DemoComponent'
+        $result | Should -Not -BeNullOrEmpty
+
+        $result.PSObject.Properties.Name | Should -Contain 'JobName'
+        $result.PSObject.Properties.Name | Should -Contain 'KomponentenTyp'
+        $result.PSObject.Properties.Name | Should -Contain 'Technologie'
+        $result.PSObject.Properties.Name | Should -Contain 'PrimaryContact'
+        $result.PSObject.Properties.Name | Should -Contain 'Email'
+    }
+    Context 'When mapping does not exist' {
+        It 'Throws an error' {
+            { Get-IdoitMappedObjectFromTemplate -MappingName 'NonExistentMapping' } | Should -Throw "No category map registered for name 'NonExistentMapping'. Use Register-IdoitCategoryMap to register a mapping."
+        }
+    }
+}

--- a/tests/Unit/Public/Get-IdoitObject.tests.ps1
+++ b/tests/Unit/Public/Get-IdoitObject.tests.ps1
@@ -10,6 +10,8 @@ BeforeAll {
     $testRoot = Join-Path -Path (Get-SamplerAbsolutePath) -ChildPath 'tests'
     $testHelpersPath = Join-Path -Path $testRoot -ChildPath 'Unit\Helpers'
     . $testHelpersPath/MockConnectIdoit.ps1
+    . $testHelpersPath/MockData_Cmdb_object_read.ps1
+    . $testHelpersPath/MockData_Cmdb_objects_read.ps1
     . $testHelpersPath/MockDefaultMockAtEnd.ps1
 }
 
@@ -23,44 +25,42 @@ AfterAll {
 
 Describe Get-IdoitObject {
     BeforeAll {
-        . $testHelpersPath/MockData_Cmdb_object_read.ps1
-        . $testHelpersPath/MockDefaultMockAtEnd.ps1
+        Start-IdoitApiTrace
     }
-    Context 'Return and not return values' {
+    AfterAll {
+        Stop-IdoitApiTrace
+    }
+    Context 'Return and not return values using method cmdb.object.read' {
         It 'Returns a single object' {
             $return = Get-IdoitObject -ObjId 540
             ($return | Measure-Object).Count | Should -Be 1
+            $return.typeId | Should -Be 5
             $return.PSObject.TypeNames | Should -Contain 'Idoit.Object'
             Assert-MockCalled Invoke-RestMethod -Times 1 -Exactly -Scope It
+            $Global:IdoItAPITrace[-1].Request.method | Should -Be 'cmdb.object.read'
         }
         It 'Returns error if no object is found' {
             Mock -CommandName Invoke-Idoit -ModuleName 'PSIdoitNG' -MockWith { $null }
             $ret = Get-IdoitObject -ObjId 540 -ErrorAction SilentlyContinue -ErrorVariable err
             $ret | Should -BeNullOrEmpty
-            $err | Should -Belike "*not found Id=540"
-            { Get-IdoitObject -ObjId 540 -ErrorAction Stop -ErrorVariable err } | Should -Throw "*not found Id=540*"
+            $err | Should -Not -BeNullOrEmpty
+            # do not check $Global:IdoItAPITrace[-1]; we where mocking Invoke-Idoit => no API call was made
         }
     }
-
-    Context 'Pipeline' {
-        It 'Accepts values from the pipeline by value' {
-            $return = 37, 540 | Get-IdoitObject
-            Assert-MockCalled Invoke-RestMethod -Times 2 -Exactly -Scope It
-            $return[0].ObjId | Should -Be 37
-            $return[1].ObjId | Should -Be 540
+    Context 'Filter by ObjectType' {
+        It 'ByNumber' {
+            $return = Get-IdoitObject -ObjectType 53
+            ($return | Measure-Object).Count | Should -BeGreaterThan 0
+            $return[0].Type_Title | Should -Be 'Persons'
+            Assert-MockCalled Invoke-RestMethod -Times 1 -Exactly -Scope It
+            $Global:IdoItAPITrace[-1].Request.method | Should -Be 'cmdb.objects.read'
         }
-
-        It 'Accepts value from the pipeline by property name' {
-            $return = 37, 540 | ForEach-Object {
-                [PSCustomObject]@{
-                    ObjId         = $_
-                    OtherProperty = 'other'
-                }
-            } | Get-IdoitObject
-
-            Assert-MockCalled Invoke-RestMethod -Times 2 -Exactly -Scope It
-            $return[0].ObjId | Should -Be 37
-            $return[1].ObjId | Should -Be 540
+        It 'ByString' {
+            $return = Get-IdoitObject -ObjectType 'C__OBJTYPE__PERSON'
+            ($return | Measure-Object).Count | Should -BeGreaterThan 0
+            $return[0].Type_Title | Should -Be 'Persons'
+            Assert-MockCalled Invoke-RestMethod -Times 1 -Exactly -Scope It
+            $Global:IdoItAPITrace[-1].Request.method | Should -Be 'cmdb.objects.read'
         }
     }
 }

--- a/tests/Unit/Public/New-IdoitMappedObject.tests.ps1
+++ b/tests/Unit/Public/New-IdoitMappedObject.tests.ps1
@@ -1,0 +1,108 @@
+BeforeAll {
+    $script:ModuleName = 'PSIdoitNG'
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $script:moduleName -Force
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+
+    $testRoot = Join-Path -Path (Get-SamplerAbsolutePath) -ChildPath 'tests'
+    $testHelpersPath = Join-Path -Path $testRoot -ChildPath 'Unit\Helpers'
+    . $testHelpersPath/MockConnectIdoIt.ps1
+    . $testHelpersPath/MockData_Cmdb_object_read.ps1
+    . $testHelpersPath/MockData_Cmdb_object_types_read.ps1
+    . $testHelpersPath/MockData_cmdb_object_type_categories_read.ps1
+    . $testHelpersPath/MockData_cmdb_category_read.ps1
+    . $testHelpersPath/MockData_cmdb_category_info_read.ps1
+    . $testHelpersPath/MockData_cmdb_dialog.ps1
+    . $testHelpersPath/MockData_idoit_constants_read.ps1
+    . $testHelpersPath/MockDefaultMockAtEnd.ps1
+}
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'New-IdoitMappedObject' {
+    BeforeEach {
+        InModuleScope -ModuleName $script:moduleName {
+            $Script:IdoitCategoryMaps = @{}
+        }
+    }
+
+    It 'Creates a new Idoit object with the specified mapping' {
+        Mock Invoke-RestMethod -ModuleName $script:moduleName -MockWith {
+            $body = $body | ConvertFrom-Json
+            [PSCustomObject] @{
+                id      = $body.id
+                jsonrpc = '2.0'
+                result  = [PSCustomObject]@{
+                    id      = 28            # new object ID: Return the one we have a mock for
+                    success = 'True'
+                    message = "Object successfully saved."
+                }
+            }
+        } -ParameterFilter {
+            (($body | ConvertFrom-Json).method) -eq 'cmdb.object.create'
+        }
+        Mock Invoke-RestMethod -ModuleName PSIdoitNG -MockWith {
+            # check request values: All properties in the simulated request param (except apikey) should be in the request
+            # returns the simulated response with the same id as the request
+            $requestBody = $body | ConvertFrom-Json
+            $requestBody.params.object | Should -Be 28
+            $requestBody.params.category | Should -Be 'C__CATS__PERSON'
+            $requestBody.params.data.id | Should -Be $null           # because readonly
+            $oneOfThemIsPresent = $requestBody.params.data.first_name -eq 'Max' -or $requestBody.params.data.last_name -eq 'Mustermann'
+            $oneOfThemIsPresent | Should -Be $true
+            # if we are here -> return response
+            $simResponse = [PSCustomObject]@{
+                id      = $requestBody.id
+                jsonrpc = '2.0'
+                result  = @{
+                    success = 'True'
+                    message = "Category entry successfully saved. [This method is deprecated and will be removed in a feature release. Use 'cmdb.category.save' instead.]"
+                }
+            }
+            $simResponse
+        } -ParameterFilter {
+            $objBody = $body | ConvertFrom-Json
+            Write-Output ($objBody.method -eq 'cmdb.category.save')
+        }
+
+        $mappingName = 'PersonMapped'
+        $yamlPath = Join-Path $testHelpersPath 'SampleMapping.yaml'
+        Register-IdoitCategoryMap -Path $yamlPath -Force
+
+        $defaultObject = Get-IdoitMappedObjectFromTemplate -MappingName $mappingName
+        $defaultObject.PSObject.Properties.Name | Should -Contain 'objId'
+        $defaultObject.PSObject.Properties.Name | Should -Contain 'Firstname'
+        $defaultObject.PSObject.Properties.Name | Should -Contain 'Lastname'
+
+        $defaultObject.Firstname = 'Max'
+        $defaultObject.Lastname = 'Mustermann'
+        # we have to suppress the warning. The current Mocked object does not have an object with ID 1234
+        $splatNewMappedObject = @{
+            InputObject     = $defaultObject
+            MappingName     = $mappingName
+            IncludeProperty = @('Firstname', 'Lastname') # only these properties are set on creation
+            WarningAction   = 'SilentlyContinue'
+            WarningVariable = 'warn'
+        }
+        $newObject = New-IdoitMappedObject @splatNewMappedObject
+        $newObject | Should -Not -BeNullOrEmpty
+        # instead of checking the return value, we check the API request
+        # 1 x create object, 2 x save (because currently I only can update 1 category attribute at a time)
+        Assert-MockCalled -ModuleName $script:moduleName -CommandName 'Invoke-RestMethod' -ParameterFilter {
+            $objBody = $body | ConvertFrom-Json
+            Write-Output ($objBody.method -eq 'cmdb.object.create')
+        } -Exactly 1 -Scope It
+        Assert-MockCalled -ModuleName $script:moduleName -CommandName 'Invoke-RestMethod' -ParameterFilter {
+            $objBody = $body | ConvertFrom-Json
+            Write-Output ($objBody.method -eq 'cmdb.category.save')
+        } -Exactly 2 -Scope It
+    }
+}

--- a/tests/Unit/Public/Set-IdoItMappedObject.tests.ps1
+++ b/tests/Unit/Public/Set-IdoItMappedObject.tests.ps1
@@ -268,7 +268,7 @@ Describe 'Set-IdoitMappedObject' {
             }
             $result = Set-IdoitMappedObject -ObjId $objId -InputObject $prevObj -PropertyMap $mapUpdate -IncludeProperty Technologie @splatWarnOff
             $result | Should -BeTrue
-            $warn | Should -Be 'No categories found for object type C__CATG__CONTACT(93)'
+            $warn | Should -BeNullOrEmpty
             # verify that a request was sent
             Assert-MockCalled -CommandName Invoke-RestMethod -ModuleName PSIdoitNG -ParameterFilter {
                 (($body | ConvertFrom-Json).method) -eq 'cmdb.category.save'


### PR DESCRIPTION
…s (#36)

* New-IdoitMappedObject, Get-IdoitMappedObjectTemplate; Fixes #34
* Get-IdoitObject: should add TypeId to returned object; fixes #35
* Add filters to allow more data to read in one call and to better limit the results; Fixes #28
* use TypeId instead of 'objecttype'