### PR TITLE
Add updateable dialog properties, optimize API calls when creating or updating mapped objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - New-IdoitObject accetps array of hashtables to allow several categories while creating
-- new func ConvertTo-IdoitObjectCategory
-- New (private) function Get-IdoitMappedObjectChange
+- add func ConvertTo-IdoitObjectCategory
+- add (private) function Get-IdoitMappedObjectChange
+- fix update (set) of dialog properties
 
 ### Minor
-- Reduce API calls when creating a mapped object
+- Reduce API calls when creating or updating a mapped object
 - Add -AllowDuplicates to be able to create objects with name that already exists
 - Better content check of config yaml
 - Enhance test cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,19 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Better content check of config yaml
 - Enhance test cases
 
-### v0.4.2
+### v0.3.2
 - Fixes to speed up Get-IdoitObjectTree
 - New func 'Get-IdoitObjectByRelation' to get references to related objects
 - 'New-IdoitMappedObecjt' removed param IncludeProperty
 - Cleanup code of unused variables
 
-### v0.4.1
+### v0.3.1
 - New-IdoitMappedObject
 - Get-IdoitMappedObjectFromTemplate
 - Get-IdoitObject added Filters
 - Search-IdoitObject added parameter -Status
 
-### v0.4.0
+### v0.3.0
 - New feature: Mapped objects
 - Standardize ObjId, TypeId properties in objects
 

--- a/build.yaml
+++ b/build.yaml
@@ -56,7 +56,7 @@ BuildWorkflow:
     - Build_Module_LocalModule
 
   generate_markdown_help: |
-    {  $DocsRootDir = 'C:\Users\wagnerw\Lokal\Github\PSIdoitNG\docs'
+    {  $DocsRootDir = Join-Path -Path (Get-SamplerAbsolutePath) -ChildPath 'docs'
       if (-not (Test-Path -Path $DocsRootDir)) {
         $null = New-Item -Path $DocsRootDir -ItemType Directory
       }

--- a/docs/en/New-IdoitMappedObject.md
+++ b/docs/en/New-IdoitMappedObject.md
@@ -27,8 +27,9 @@ The mapping must be registered using \`Register-IdoitCategoryMap\` before callin
 
 ### EXAMPLE 1
 ```
-New-IdoitMappedObject -InputObject $inputObject -MappingName 'MyMapping' -ExcludeProperty 'Tags'
-Creates a new Idoit object using the specified mapping, excluding the 'Tags' property from the input object.
+New-IdoitMappedObject -InputObject $inputObject -MappingName 'MyMapping' -IncludeProperty 'Name', 'Description' -ExcludeProperty 'Tags'
+Creates a new Idoit object using the specified mapping, including only the 'Name' and 'Description' properties,
+and excluding the 'Tags' property from the input object.
 ```
 
 ## PARAMETERS

--- a/src/Private/ValidateProperties.ps1
+++ b/src/Private/ValidateProperties.ps1
@@ -71,7 +71,7 @@ function ValidateProperties {
                     continue
                 }
                 $thisDialogOptions = Get-IdoitDialog -params @{ category = $Category; property = $key } -ErrorAction Stop
-                $valid = $thisDialogOptions.title -contains $Properties[$key]
+                $valid = $thisDialogOptions.title -contains $Properties[$key] -or $thisDialogOptions.Id -contains $Properties[$key]
                 if (-not $valid) {
                     $atLeastOneFailed = $true
                     Write-Warning "Value '$($Properties[$key])' for property '$key' is not valid for category '$($Category)'. Valid values are: $($thisDialogOptions.title -join ', ')"

--- a/src/Public/Compare-ObjectProperty.ps1
+++ b/src/Public/Compare-ObjectProperty.ps1
@@ -1,0 +1,103 @@
+function Compare-ObjectProperty {
+    <#
+    .SYNOPSIS
+    Compares specific properties of two objects and returns the differences.
+    .DESCRIPTION
+    In contrast to the built-in Compare-Object cmdlet, this function will return a side-by-side comparison of specified properties from two objects.
+    .PARAMETER ReferenceObject
+    The first object to compare.
+    .PARAMETER DifferenceObject
+    The second object to compare.
+    .PARAMETER PropertyList
+    The list of properties to compare. If not specified, all properties will be compared.
+    .PARAMETER IncludeEqual
+    If specified, properties that are equal in both objects will also be included in the output.
+    .OUTPUTS
+    A custom object containing the property name, reference value, difference value, and side indicator.
+    .EXAMPLE
+    $obj1 = [PSCustomObject]@{ Name = "Alice"; Age = 30; City = "New York"; Property1 = "Value1" }
+    $obj2 = [PSCustomObject]@{ Name = "Alice"; Age = 32; City = "Los Angeles"; Property2 = "Value2" }
+    Compare-ObjectProperty -ReferenceObject $obj1 -DifferenceObject $obj2
+    Name      ReferenceValue  SideIndicator DifferenceValue
+    --------  --------------- ------------- ---------------
+    Age       30              <>            32
+    City      New York        <>            Los Angeles
+    Property1 Value1          <=
+    Property2                 =>            Value2
+    .EXAMPLE
+    $obj1 = [PSCustomObject]@{ Name = "Alice"; Age = 30; City = "New York"; Property1 = "Value1" }
+    $obj2 = [PSCustomObject]@{ Name = "Alice"; Age = 32; City = "Los Angeles"; Property2 = "Value2" }
+    Compare-ObjectProperty -ReferenceObject $obj1 -DifferenceObject $obj2 -IncludeEqual
+    Name      ReferenceValue  SideIndicator DifferenceValue
+    --------  --------------- ------------- ---------------
+    Name      Alice           ==            Alice
+    Age       30              <>            32
+    City      New York        <>            Los Angeles
+    Property1 Value1          <=
+    Property2                 =>            Value2
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        $ReferenceObject,
+        [Parameter(Mandatory = $true)]
+        $DifferenceObject,
+        [string[]]$PropertyList,
+        [switch]$IncludeEqual
+    )
+
+    begin {
+
+    }
+
+    process {
+        $allProperties = @()
+        if ($null -ne $PropertyList -and $PropertyList.Count -gt 0) {
+            $allProperties = $PropertyList
+        } else {
+            $allProperties = ($ReferenceObject | Get-Member -MemberType NoteProperty, Property).Name
+            $allProperties += ($DifferenceObject | Get-Member -MemberType NoteProperty, Property).Name
+            $allProperties = $allProperties | Select-Object -Unique
+        }
+
+        $resultList =foreach ($prop in $allProperties) {
+            $refValue = $ReferenceObject.PSObject.Properties[$prop]?.Value
+            $diffValue = $DifferenceObject.PSObject.Properties[$prop]?.Value
+            $refValueString = $refValue | Out-String
+            $diffValueString = $diffValue | Out-String
+
+            if ($refValueString -eq $diffValueString) {
+                if ($IncludeEqual.IsPresent) {
+                    [PSCustomObject]@{
+                        Name           = $prop
+                        ReferenceValue = $refValue
+                        SideIndicator  = '=='
+                        DifferenceValue= $diffValue
+                    }
+                }
+            } else {
+                $sideIndicator = ''
+                if ($null -ne $refValue -and $null -ne $diffValue) {
+                    $sideIndicator = '<>'
+                } elseif ($null -ne $refValue) {
+                    $sideIndicator = '<='
+                } else {
+                    $sideIndicator = '=>'
+                }
+
+                [PSCustomObject]@{
+                    Name           = $prop
+                    ReferenceValue = $refValue
+                    SideIndicator  = $sideIndicator
+                    DifferenceValue= $diffValue
+                }
+            }
+        }
+
+        return $resultList
+    }
+
+    end {
+
+    }
+}

--- a/src/Public/ConvertTo-IdoitObjectCategory.ps1
+++ b/src/Public/ConvertTo-IdoitObjectCategory.ps1
@@ -18,6 +18,13 @@ function ConvertTo-IdoitObjectCategory {
     The name of the mapping to be used for the update.
     This is a name of a mapping registered with Register-IdoitCategoryMap.
 
+    .PARAMETER PropertyMap
+    A mapping object that defines how the properties of the input object map to the I-doit categories.
+
+    .PARAMETER IncludeProperty
+    An array of properties to include in the conversion.
+    Use '*' to include all properties defined in the mapping.
+
     .PARAMETER ExcludeProperty
     An array of properties to exclude from the conversion.
     This might be useful to prepare an object for a specific update, where some properties should not be updated later on.
@@ -42,6 +49,12 @@ function ConvertTo-IdoitObjectCategory {
         [ValidateNotNullOrEmpty()]
         [Alias('Name')]
         [string] $MappingName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'PropertyMap')]
+        [ValidateNotNullOrEmpty()]
+        $PropertyMap,
+
+        [string[]] $IncludeProperty = @(),
 
         [string[]] $ExcludeProperty = @()
     )
@@ -83,36 +96,59 @@ function ConvertTo-IdoitObjectCategory {
                     Continue            # unsupported category
                 }
                 $resultCategoriesAttributes[$thisMapping.Category] = @{}
-                $PSpropNameList = $thisMapping.PropertyList.PSProperty | Where-Object { $_ -notin $ExcludeProperty }
-                foreach ($propListItem in ($thisMapping.PropertyList | Where-Object { $_.PSProperty -in $PSpropNameList })) {
+                if ($IncludeProperty -eq '*') {
+                    $IncludeProperty = $thisMapping.PropertyList.PSProperty
+                }
+                $propList = $thisMapping.PropertyList | Where-Object {
+                    $_.PSProperty -notin $ExcludeProperty -and ($_.PSProperty -in $IncludeProperty -or $_.Update -eq $true)
+                }
+                foreach ($propListItem in $propList) {
                     $attr, $field, $index = $propListItem.iAttribute -split '\.'
-                    # if a property name is not found -> skip the attribute
-                    if ($srcObject.PSObject.Properties.Name -notcontains $propListItem.PSProperty) {
-                        Write-Warning "Property $($propListItem.PSProperty) not found in input object. Skipping conversion for $($thisMapping.Category).$($attr)"
+                    if ($attr -eq '*') {
+                        Write-Verbose "Wildcard attributes are not supported in ConvertTo-IdoitObjectCategory. Skipping conversion for $($thisMapping.Category).$($attr)"
                         continue
                     }
-                  # id is automatically inserted by API
+                    # if a property name is not found -> skip the attribute
+                    if ($srcObject.PSObject.Properties.Name -notcontains $propListItem.PSProperty) {
+                        Write-Verbose "Property $($propListItem.PSProperty) not found in input object. Skipping conversion for $($thisMapping.Category).$($attr)"
+                        continue
+                    }
+                    # id is automatically inserted by API
                     if (-not [string]::IsNullOrEmpty($propListItem.Action)) {
                         Write-Warning "Property $($propListItem.PSProperty) has an action defined ($($propListItem.Action)). This is not supported in ConvertTo-IdoitObjectCategory. Skipping conversion for $($thisMapping.Category).$($attr)"
                         continue
                     }
+                    #Depending on the field type, we have to set different values
+                    $valueToSet = $srcObject.$($propListItem.PSProperty)
+                    if ($propListItem.iInfo.type -in ('dialog', 'dialog_plus')) {
+                        # in this case, it's only possible to set a "simple" value (id or title)
+                        if ($srcObject.$($propListItem.PSProperty) -is [PSCustomObject]) {
+                            if ($srcObject.$($propListItem.PSProperty).PSObject.Properties.Name -contains 'title') {
+                                $valueToSet = $srcObject.$($propListItem.PSProperty).title
+                            } elseif ($srcObject.$($propListItem.PSProperty).PSObject.Properties.Name -contains 'id') {
+                                $valueToSet = $srcObject.$($propListItem.PSProperty).id
+                            } else {
+                                Write-Warning "Property $($propListItem.PSProperty) is a dialog object but does not contain 'id' or 'title'. Skipping conversion for $($thisMapping.Category).$($attr)"
+                                continue
+                            }
+                        }
+                        $field = ''  # for dialog fields, we do not need to set a subfield
+                    }
                     if ([string]::IsNullOrEmpty($field)) {
-                        $resultCategoriesAttributes[$thisMapping.Category][$attr] = $srcObject.$($propListItem.PSProperty)
+                            $resultCategoriesAttributes[$thisMapping.Category][$attr] = $valueToSet
                     } else {
                         # multiselect fields are stored as a string array
                         if ($propListItem.iInfo.type -eq 'multiselect') {
-                            $resultCategoriesAttributes[$thisMapping.Category][$attr] = @($srcObject.$($propListItem.PSProperty))
+                            $resultCategoriesAttributes[$thisMapping.Category][$attr] = @($valueToSet)
                         } else {
-                            $resultCategoriesAttributes[$thisMapping.Category][$attr] = @{
-                                $field = $srcObject.$($propListItem.PSProperty)
-                            }
+                            $resultCategoriesAttributes[$thisMapping.Category][$attr] = @{ $field = $valueToSet }
                         }
                     }
                 }
                 if ($resultCategoriesAttributes[$thisMapping.Category].Keys.Count -eq 0) {
                     # if no properties are set, we do not want to update this category
                     $resultCategoriesAttributes.Remove($thisMapping.Category)
-                    Write-Warning "No properties found for category '$($thisMapping.Category)'. Skipping conversion."
+                    Write-Verbose "No properties found for category '$($thisMapping.Category)'. Skipping conversion."
                 }
             }
         }

--- a/src/Public/New-IdoitMappedObject.ps1
+++ b/src/Public/New-IdoitMappedObject.ps1
@@ -68,8 +68,8 @@ function New-IdoitMappedObject {
     process {
         # we have to exclude id, objId because to avoid these if somebody cloned a mapped object
         # and tries to create a new object with the same parameters
-        $idoitCategoryHash = ConvertTo-IdoitObjectCategory -InputObject $InputObject -MappingName $MappingName -ExcludeProperty (@('id','ObjID') + $ExcludeProperty)
-        if ($PSCmdlet.ShouldProcess("Creating new Idoit object of type '$($mapping.IdoitObjectType)'")) {
+        $idoitCategoryHash = ConvertTo-IdoitObjectCategory -InputObject $InputObject -MappingName $MappingName -ExcludeProperty (@('id','ObjID') + $ExcludeProperty) -IncludeProperty '*'
+        if ($PSCmdlet.ShouldProcess("type '$($mapping.IdoitObjectType)'" + " with title '$Title'")) {
             $apiResult = New-IdoitObject -Name $Title -ObjectType $mapping.IdoitObjectType -Category $idoitCategoryHash -AllowDuplicates:$AllowDuplicates
             if ($apiResult.Success) {
                 Write-Output $apiResult.objId

--- a/src/Public/Set-IdoItMappedObject.ps1
+++ b/src/Public/Set-IdoItMappedObject.ps1
@@ -53,6 +53,7 @@ function Set-IdoitMappedObject {
     .NOTES
     #>
     [CmdletBinding(SupportsShouldProcess=$true, DefaultParameterSetName = 'MappingName')]
+    [OutputType([bool])]
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -75,103 +76,30 @@ function Set-IdoitMappedObject {
         [string[]] $ExcludeProperty = @()
     )
 
-    begin {
-        # in case of -WhatIf, we do not want to update the object
-        if ($PSCmdlet.ParameterSetName -eq 'MappingName') {
-            if ($null -eq $Script:IdoitCategoryMaps -or -not $Script:IdoitCategoryMaps.ContainsKey($MappingName)) {
-                Write-Error "No category map registered for name '$MappingName'. Use Register-IdoitCategoryMap to register a mapping." -ErrorAction Stop
-            }
-            $PropertyMap = $Script:IdoitCategoryMaps[$MappingName]
-        }
-    }
+    begin {}
 
     process {
-        $obj = Get-IdoItObject -ObjId $ObjId
-        if ($null -eq $obj) {
-            Write-Warning "Object with objId $ObjId not found. Please use New-IdoitObject or Get-IdoItObject to get the object to change"
-            return
+        $splatMapping = @{}
+        if ($PSCmdlet.ParameterSetName -eq 'MappingName') {
+            $splatMapping.MappingName = $MappingName
+        } else {
+            $splatMapping.PropertyMap = $PropertyMap
         }
-        $objTypeCatList = Get-IdoItObjectTypeCategory -Type $obj.Objecttype
-        if ($null -eq $objTypeCatList) {
-            Throw "No categories found for object type $($obj.Objecttype)"
-            return
+        $prevObj = Get-IdoItMappedObject -ObjId $ObjId @splatMapping
+        if ($null -eq $prevObj) {
+            Throw "Object with objId $ObjId not found for Update."
         }
-        $notfoundCatList = $PropertyMap.mapping.category | Where-Object { $_ -notin $objTypeCatList.const }
-        if ($notfoundCatList) {
-            Throw "Mapping categories $($notfoundCatList -join ', ') not found for object type $($obj.Objecttype)/$($obj.type_title)"
-            return
+        $diff = Compare-ObjectProperty -ReferenceObject $prevObj -DifferenceObject $InputObject -PropertyList ($srcObject.PSObject.Properties.Name)
+        if ($null -eq $diff) {
+            Write-Verbose "ObjId: $ObjId; No changes detected for object; no update required."
+            return $true
         }
-        # get those categories, which are used in the mapping
-        $usedCatList = $objTypeCatList | Where-Object const -in $PropertyMap.mapping.category
-        if ($null -eq $usedCatList) {
-            Write-Warning "No categories found for object type $($obj.Objecttype)"
-            return
-        }
-        # # multi_value categories are not supported yet
-        # $multiValueCatList = $usedCatList | Where-Object { $_.multi_value -ne 0 }
-        # foreach ($mv in $multiValueCatList) {
-        #     Write-Warning "Categories $($mv.const) is a multi value category. This is not supported yet."
-        #     $usedCatList = $usedCatList | Where-Object { $_.const -ne $mv.const }
-        # }
-
-        $srcObject = $InputObject
+        Write-Verbose "ObjId: $ObjId; Changes detected ; updating properties."
+        $srcObject = $InputObject | Select-Object -Property $diff.Name
+        $srcCategoryList = ConvertTo-IdoitObjectCategory -InputObject $srcObject @splatMapping -ExcludeProperty $ExcludeProperty -IncludeProperty $IncludeProperty
         $overallSucess = $true
-        foreach ($propMap in $PropertyMap) {
-            foreach ($thisMapping in $propMap.Mapping) {
-                $thisCat = $usedCatList | Where-Object { $_.Const -eq $thisMapping.Category }
-                if ($null -eq $thisCat) {
-                    Continue            # unsupported category
-                }
-                $catValues = Get-IdoItCategory -ObjId $obj.Id -Category $thisMapping.Category
-                if ($null -eq $catValues) {
-                    Write-Verbose "No categories found for object type $($thisMapping.Category)($($obj.Objecttype)); Should be new"
-                }
-                # if no action is defined, add the property. If the corresponding catvalue holds an array, the property is added as an array
-                # TODO: Multivalue categories are not supported yet
-
-                # create a list of property names to update
-                #   include those which are defined in the mapping as updateable
-                #           those which are defined by IncludeProperty parameter
-                #   exclude those which are defined by ExcludeProperty parameter
-                $PSpropNameList = @($thisMapping.PropertyList | Where-Object { $_.Update -eq $true }).PSProperty + $IncludeProperty | Where-Object { $_ -notin $ExcludeProperty }
-                foreach ($propListItem in ($thisMapping.PropertyList | Where-Object { $_.PSProperty -in $PSpropNameList -and [String]::IsNullOrEmpty($_.Action) })) {
-                    $attr, $field, $index = $propListItem.iAttribute -split '\.'
-                    if ($attr[0] -eq '!') {
-                        Write-Error "The iAttribute '$($propListItem.iAttribute)' is not supported for update. It must be or be a simple key."
-                        continue
-                    }
-                    # arrays are currently support under the condition that the attribute has a dialog or dialog_plus ui
-                    if ($catValues.$($attr) -is [System.Array]) {
-                        $catInfo = Get-IdoItCategoryInfo -Category $thisMapping.Category
-                        if ($catInfo.$attr.info.type -notin @('dialog', 'dialog_plus','multiselect')) {
-                            Write-Warning "The iAttribute '$($propListItem.iAttribute)' is not a dialog,dialog_plus or multiselect type. Arrays are not supported for this type."
-                            continue
-                        }
-                        $changedProperty = [string]::Format("{0}.{1}: {2}->{3}", $thisMapping.Category, $attr,
-                            ($catValues.$attr.$field -join ', '), ($srcObject.$($propListItem.PSProperty) -join ', '))
-                        if ($PSCmdlet.ShouldProcess($changedProperty, "Update property $($obj.Title)")) {
-                            Write-Verbose "Updating property $changedProperty"
-                            $result = Set-IdoItCategory -ObjId $obj.Id -Category $thisMapping.Category -Data @{
-                                $attr = $srcObject.$($propListItem.PSProperty)
-                            }
-                            $overallSucess = $overallSucess -and $result.success
-                        }
-                    } else {
-                        # change only if the value is different; Case sensitive!
-                        if ($catValues.$attr.$field -cne $srcObject.$($propListItem.PSProperty)) {
-                            $changedProperty = [string]::Format("{0}.{1}. {2}->{3}", $thisMapping.Category, $propListItem.iAttribute,
-                                $catValues.$($propListItem.iAttribute), $srcObject.$($propListItem.PSProperty))
-                            if ($PSCmdlet.ShouldProcess($changedProperty, "Update property $($obj.Title)")) {
-                                Write-Verbose "Updating property $changedProperty"
-                                $result = Set-IdoItCategory -ObjId $obj.Id -Category $thisMapping.Category -Data @{
-                                    $attr = $srcObject.$($propListItem.PSProperty)
-                                }
-                                $overallSucess = $overallSucess -and $result.success
-                            }
-                        }
-                    }
-                }
-            }
+        foreach ($catName in $srcCategoryList.Keys) {
+                Set-IdoItCategory -ObjId $ObjId -Category $catName -Data $srcCategoryList[$catName]
         }
         Write-Output $overallSucess
     }

--- a/tests/Integration/ConvertTo-IdoitObjectCategory.Tests.ps1
+++ b/tests/Integration/ConvertTo-IdoitObjectCategory.Tests.ps1
@@ -1,0 +1,94 @@
+BeforeDiscovery {
+    $isNotConnected = $false
+    if ([string]::IsNullOrEmpty($uri) -or [string]::IsNullOrEmpty($apikey) -or $null -eq $credIdoit) {
+        Write-Warning -Message "You need to set the variables `$uri`, `$apikey`, and `$credIdoit` before running the tests."
+        $isNotConnected = $true
+    }
+}
+BeforeAll {
+    $script:ModuleName = 'PSIdoitNG'
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $script:moduleName -Force
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+
+    $testRoot = Join-Path -Path (Get-SamplerAbsolutePath) -ChildPath 'tests'
+    $testHelpersPath = Join-Path -Path $testRoot -ChildPath 'Unit\Helpers'
+    $testIntegrationHelpersPath = Join-Path -Path $testRoot -ChildPath 'Integration\Helpers'
+    if (-not $IsNotConnected) {
+        Connect-Idoit -Uri $uri -Credential $credIdoit -ApiKey (ConvertFrom-SecureString $apikey -AsPlainText)
+    }
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Disconnect-Idoit -ErrorAction SilentlyContinue
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+}
+Describe 'Integration Set-IdoitMappedObject' -Tag 'Integration' -Skip:$isNotConnected {
+    BeforeAll {
+        & (Join-Path $testIntegrationHelpersPath Remove-PesterLeftOvers.ps1)
+        Register-IdoitCategoryMap -Path (Join-Path -Path $testHelpersPath -ChildPath 'SampleMapping.yaml') -Force
+    }
+    AfterEach {
+        & (Join-Path $testIntegrationHelpersPath Remove-PesterLeftOvers.ps1)
+    }
+    Context 'CustomObject' {
+        It 'converts popup with simple value' {
+            $mappingName = 'CustomObjectMapped'
+            $nameTestObject = "Pester $(Get-Date -Format 'yyyy-MM-dd hh:mm:ss') $(New-Guid)"
+            $testObject = [PSCustomObject]@{
+                ComponentType = 'Job / Schnittstelle'
+            }
+            $splatConvert = @{
+                InputObject     = $testObject
+                MappingName     = $mappingName
+            }
+            $ret = ConvertTo-IdoitObjectCategory @splatConvert
+            $ret | Should -BeOfType 'Hashtable'
+            $ret.C__CATG__CUSTOM_FIELDS_KOMPONENTE['f_popup_c_17289168067044910'] | Should -Be 'Job / Schnittstelle'
+        }
+        It 'converts popup with full popup object to title string' {
+            $mappingName = 'CustomObjectMapped'
+            # $nameTestObject = "Pester $(Get-Date -Format 'yyyy-MM-dd hh:mm:ss') $(New-Guid)"
+            $testObject = [PSCustomObject]@{
+                CustomProperty = [PSCustomObject]@{
+                    id    = 85
+                    title = 'Job / Schnittstelle'
+                }
+            }
+            $splatConvert = @{
+                InputObject     = $testObject
+                MappingName     = $mappingName
+            }
+            $ret = ConvertTo-IdoitObjectCategory @splatConvert
+            $ret | Should -BeOfType 'Hashtable'
+            $ret.C__CATG__CUSTOM_FIELDS_KOMPONENTE['f_popup_c_17289168067044910'] | Should -Be 'Job / Schnittstelle'
+        }
+    }
+    It 'converts more than one category' {
+        $mappingName = 'ServerMapped'
+        $testObject = [PSCustomObject]@{
+            ComputerName            = 'pester-test-server'
+            BeschreibungUndefined   = 'Test server for Pester'
+            MemoryGB                = 16
+            CategoryAsArray         = 16384
+        }
+        $splatConvert = @{
+            InputObject     = $testObject
+            MappingName     = $mappingName
+        }
+        $ret = ConvertTo-IdoitObjectCategory @splatConvert
+        $ret | Should -BeOfType 'Hashtable'
+        $ret.C__CATG__GLOBAL.title | Should -Be 'pester-test-server'
+        $ret.C__CATG__GLOBAL.description | Should -Be 'Test server for Pester'
+        $ret.C__CATG__MEMORY.CategoryAsArray | Should -Not -BeNullOrEmpty   # value would be invalid, but it's just do see if the property is set
+        $ret.Properties.Name | Should -Not -Contain 'Tag'           # is not in the property of the object
+        $ret.Properties.Name | Should -Not -Contain 'MemoryGB'      # is excluded because is a script property
+    }
+}

--- a/tests/Integration/Get-IdoitMappedObject.Tests.ps1
+++ b/tests/Integration/Get-IdoitMappedObject.Tests.ps1
@@ -32,7 +32,7 @@ AfterAll {
 }
 
 Describe 'Integration Get-IdoitMappedObject' -Tag 'Integration' -Skip:$isNotConnected {
-        BeforeAll {
+    BeforeAll {
         & (Join-Path $testIntegrationHelpersPath Remove-PesterLeftOvers.ps1)
         Register-IdoitCategoryMap -Path (Join-Path -Path $testHelpersPath -ChildPath 'SampleMapping.yaml') -Force
     }

--- a/tests/Integration/New-IdoitMappedObject.Tests.ps1
+++ b/tests/Integration/New-IdoitMappedObject.Tests.ps1
@@ -45,6 +45,7 @@ Describe 'Integration New-IdoitMappedObject' -Tag 'Integration' -Skip:$isNotConn
             $object = [PSCustomObject]@{
                 FirstName = 'John'
                 LastName  = $nameTestObject
+                CmdbStatus = 10
             }
             $objId = New-IdoitMappedObject -InputObject $object -MappingName 'PersonMapped' -Title 'Ignored'
             Write-Host "Created new object with Id: $($objId)" -ForegroundColor Cyan
@@ -129,6 +130,53 @@ Describe 'Integration New-IdoitMappedObject' -Tag 'Integration' -Skip:$isNotConn
             $obj = Get-IdoitMappedObject -Title "$nameTestObject" -MappingName 'ServerMapped'
             $obj | Should -Not -BeNullOrEmpty
             $obj.ObjId | Should -Be $objId
+        }
+    }
+    Context 'CustomObject' {
+        BeforeAll {
+            Register-IdoitCategoryMap -Path (Join-Path -Path $testHelpersPath -ChildPath 'SampleMapping.yaml') -Force
+        }
+        It 'Creates a new mapped CUSTOM object' {
+            $VerbosePreference = 'Continue'
+            $mappingName = 'CustomObjectMapped'
+            $nameTestObject = "Pester $(Get-Date -Format 'yyyy-MM-dd hh:mm:ss') $(New-Guid)"
+            $testObject = [PSCustomObject]@{
+                ComponentType = 'Job / Schnittstelle'
+            }
+            $splatNewMappedObject = @{
+                InputObject     = $testObject
+                MappingName     = $mappingName
+                Title           = $nameTestObject
+            }
+            $result = New-IdoitMappedObject @splatNewMappedObject
+            $result | Should -BeGreaterThan 0
+
+            # read by Id
+            $obj = Get-IdoitMappedObject -ObjId $result -MappingName $mappingName
+            $obj | Should -Not -BeNullOrEmpty
+            $obj.ComponentType | Should -Be 'Job / Schnittstelle'
+            $obj.CustomProperty.Id | Should -Be 85  # id of 'Job / Schnittstelle' in my test system
+            $obj.CustomProperty.Title | Should -Be 'Job / Schnittstelle'
+
+            # now store the CustomProperty as PSCustomObject for later reuse;
+            # then change the $obj.ComponentType and update the object; this should update also the CustomProperty
+            $beforeCustomProperty = $obj.CustomProperty
+            $obj.ComponentType = 'REST-Service'
+            Set-IdoitMappedObject -ObjId $obj.ObjId -MappingName $mappingName -InputObject $obj -IncludeProperty 'ComponentType'
+            $objUpdated = Get-IdoitMappedObject -ObjId $result -MappingName $mappingName
+            $objUpdated | Should -Not -BeNullOrEmpty
+            $objUpdated.ComponentType | Should -Be 'REST-Service'
+            $objUpdated.CustomProperty.Id | Should -Be 132  # id of 'REST-Service' in my test system
+            $objUpdated.CustomProperty.Title | Should -Be 'REST-Service'
+
+            # now let's try to change the CustomProperty directly
+            $objUpdated.CustomProperty = $beforeCustomProperty
+            Set-IdoitMappedObject -ObjId $objUpdated.ObjId -MappingName $mappingName -InputObject $objUpdated -IncludeProperty 'CustomProperty'
+            $objReverted = Get-IdoitMappedObject -ObjId $result -MappingName $mappingName
+            $objReverted | Should -Not -BeNullOrEmpty
+            $objReverted.ComponentType | Should -Be 'Job / Schnittstelle'
+            $objReverted.CustomProperty.Id | Should -Be 85  # id of 'Job / Schnittstelle' in my test system
+            $objReverted.CustomProperty.Title | Should -Be 'Job / Schnittstelle'
         }
     }
 }

--- a/tests/Integration/Set-IdoitMappedObject.Tests.ps1
+++ b/tests/Integration/Set-IdoitMappedObject.Tests.ps1
@@ -1,0 +1,111 @@
+BeforeDiscovery {
+    $isNotConnected = $false
+    if ([string]::IsNullOrEmpty($uri) -or [string]::IsNullOrEmpty($apikey) -or $null -eq $credIdoit) {
+        Write-Warning -Message "You need to set the variables `$uri`, `$apikey`, and `$credIdoit` before running the tests."
+        $isNotConnected = $true
+    }
+}
+BeforeAll {
+    $script:ModuleName = 'PSIdoitNG'
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $script:moduleName -Force
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+
+    $testRoot = Join-Path -Path (Get-SamplerAbsolutePath) -ChildPath 'tests'
+    $testHelpersPath = Join-Path -Path $testRoot -ChildPath 'Unit\Helpers'
+    $testIntegrationHelpersPath = Join-Path -Path $testRoot -ChildPath 'Integration\Helpers'
+    if (-not $IsNotConnected) {
+        Connect-Idoit -Uri $uri -Credential $credIdoit -ApiKey (ConvertFrom-SecureString $apikey -AsPlainText)
+    }
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Disconnect-Idoit -ErrorAction SilentlyContinue
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Integration Set-IdoitMappedObject' -Tag 'Integration' -Skip:$isNotConnected {
+        BeforeAll {
+        & (Join-Path $testIntegrationHelpersPath Remove-PesterLeftOvers.ps1)
+        Register-IdoitCategoryMap -Path (Join-Path -Path $testHelpersPath -ChildPath 'SampleMapping.yaml') -Force
+    }
+    AfterAll {
+        & (Join-Path $testIntegrationHelpersPath Remove-PesterLeftOvers.ps1)
+    }
+    Context 'PERSON' {
+        It 'Updates a mapped PERSON object by setting cmdb_status directly via mappped property CMDBStatus' {
+            # create the test object first
+            $nameTestObject = "Pester $(Get-Date -Format 'yyyy-MM-dd hh:mm:ss') $(New-Guid)"
+            $object = [PSCustomObject]@{
+                FirstName = 'John'
+                LastName  = $nameTestObject
+                CmdbStatus = 10             # Initial status 'inoperative'
+            }
+            $objId = New-IdoitMappedObject -InputObject $object -MappingName 'PersonMapped' -Title 'Ignored'
+            Write-Host "Created new object with Id: $($objId)" -ForegroundColor Cyan
+            $objId | Should -BeGreaterThan 0
+
+            # try to reread by Id
+            $obj = Get-IdoitMappedObject -ObjId $objId -MappingName 'PersonMapped'
+            $obj | Should -Not -BeNullOrEmpty
+            $obj.FirstName | Should -Be 'John'
+            $obj.LastName | Should -Be $nameTestObject
+            $obj.CmdbStatus.Id | Should -Be 10                  # the mapping returns an object here with all attributes
+            $obj.CmdbStatus.Title | Should -Be 'inoperative'
+            $obj.CMDBStatusTitle | Should -Be 'inoperative'     # additional mapped property just returning the title
+
+            # now update the object
+            $object.CmdbStatus = 6  # Change status to 'active'
+            Set-IdoitMappedObject -InputObject $object -ObjId $objId -MappingName 'PersonMapped' -IncludeProperty 'CmdbStatus' -WhatIf:$false
+
+            # try to reread by Id
+            $obj = Get-IdoitMappedObject -ObjId $objId -MappingName 'PersonMapped'
+            $obj | Should -Not -BeNullOrEmpty
+            $obj.FirstName | Should -Be 'John'
+            $obj.LastName | Should -Be $nameTestObject
+            $obj.CmdbStatus.Id | Should -Be 6
+            $obj.CMDBStatusTitle | Should -Be 'in operation'
+        }
+        It 'Updates a mapped PERSON object by setting cmdb_status indirectly via mapped property cmdb_status.title' {
+            # this is different to usual setting of a single property value. Reason: It is a dialog field, which requires the id od title assigned to it for update.
+            # create the test object first
+            $nameTestObject = "Pester $(Get-Date -Format 'yyyy-MM-dd hh:mm:ss') $(New-Guid)"
+            $createdObject = [PSCustomObject]@{
+                FirstName = 'John'
+                LastName  = $nameTestObject
+                CmdbStatus = 10             # Initial status 'inoperative'
+            }
+            $objId = New-IdoitMappedObject -InputObject $createdObject -MappingName 'PersonMapped' -Title 'Ignored'
+            Write-Host "Created new object with Id: $($objId)" -ForegroundColor Cyan
+            $objId | Should -BeGreaterThan 0
+
+            # try to reread by Id
+            $obj = Get-IdoitMappedObject -ObjId $objId -MappingName 'PersonMapped'
+            $obj | Should -Not -BeNullOrEmpty
+            $obj.FirstName | Should -Be 'John'
+            $obj.LastName | Should -Be $nameTestObject
+            $obj.CmdbStatus.Id | Should -Be 10                  # the mapping returns an object here with all attributes
+            $obj.CmdbStatus.Title | Should -Be 'inoperative'
+            $obj.CMDBStatusTitle | Should -Be 'inoperative'     # additional mapped property just returning the title
+
+            # now update the object
+            $obj.CmdbStatusTitle = 'in operation'  # Change status to 'active'
+            Set-IdoitMappedObject -InputObject $obj -ObjId $objId -MappingName 'PersonMapped' -IncludeProperty 'CmdbStatusTitle' -WhatIf:$false
+
+            # try to reread by Id
+            $obj = Get-IdoitMappedObject -ObjId $objId -MappingName 'PersonMapped'
+            $obj | Should -Not -BeNullOrEmpty
+            $obj.FirstName | Should -Be 'John'
+            $obj.LastName | Should -Be $nameTestObject
+            $obj.CmdbStatus.Id | Should -Be 6
+            $obj.CMDBStatusTitle | Should -Be 'in operation'
+        }
+    }
+}

--- a/tests/Unit/Helpers/SampleMapping.yaml
+++ b/tests/Unit/Helpers/SampleMapping.yaml
@@ -8,6 +8,11 @@ PersonMapped:
         PSProperty: FirstName
       last_name:
         PSProperty: LastName
+    C__CATG__GLOBAL:
+      cmdb_status:
+        PSProperty: CMDBStatus
+      cmdb_status.title:
+        PSProperty: CMDBStatusTitle
 
 ServerMapped:
   IdoitObjectType: C__OBJTYPE__SERVER
@@ -69,3 +74,13 @@ ServerMapped:
                   Default { Write-Error "Unknown unit $_" }
               }
             } | Measure-Object -Sum | Select-Object -ExpandProperty Sum
+
+CustomObjectMapped:
+  PSType: CustomObject
+  IdoitObjectType: C__COMPONENT
+  Category:
+    - C__CATG__CUSTOM_FIELDS_KOMPONENTE:
+          f_popup_c_17289168067044910.title:    # your custom field identifier
+            PSProperty: ComponentType
+          f_popup_c_17289168067044910:
+            PSProperty: CustomProperty

--- a/tests/Unit/Private/Compare-ObjectProperty.Tests.ps1
+++ b/tests/Unit/Private/Compare-ObjectProperty.Tests.ps1
@@ -1,0 +1,119 @@
+BeforeDiscovery {
+    $isNotConnected = $false
+    if ([string]::IsNullOrEmpty($uri) -or [string]::IsNullOrEmpty($apikey) -or $null -eq $credIdoit) {
+        Write-Warning -Message "You need to set the variables `$uri`, `$apikey`, and `$credIdoit` before running the tests."
+        $isNotConnected = $true
+    }
+}
+BeforeAll {
+    $script:ModuleName = 'PSIdoitNG'
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+    Import-Module -Name $script:moduleName -Force
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+
+    $testRoot = Join-Path -Path (Get-SamplerAbsolutePath) -ChildPath 'tests'
+    $testHelpersPath = Join-Path -Path $testRoot -ChildPath 'Unit\Helpers'
+    $testIntegrationHelpersPath = Join-Path -Path $testRoot -ChildPath 'Integration\Helpers'
+    if (-not $IsNotConnected) {
+        Connect-Idoit -Uri $uri -Credential $credIdoit -ApiKey (ConvertFrom-SecureString $apikey -AsPlainText)
+    }
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Disconnect-Idoit -ErrorAction SilentlyContinue
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+}
+Describe 'Compare-ObjectProperty' {
+    BeforeAll {
+        $obj1 = [PSCustomObject]@{ Name = "Alice"; Age = 30; City = "New York"; Property1 = "Value1" }
+        $obj2 = [PSCustomObject]@{ Name = "Alice"; Age = 32; City = "Los Angeles"; Property2 = "Value2" }
+    }
+    It 'compares two objects and shows differences' {
+        $result = Compare-ObjectProperty -ReferenceObject $obj1 -DifferenceObject $obj2
+        $result | Should -Not -BeNullOrEmpty
+        $result.Count | Should -Be 4
+
+        $ageDiff = $result | Where-Object { $_.Name -eq 'Age' }
+        $ageDiff.ReferenceValue | Should -Be 30
+        $ageDiff.DifferenceValue | Should -Be 32
+        $ageDiff.SideIndicator | Should -Be '<>'
+
+        $cityDiff = $result | Where-Object { $_.Name -eq 'City' }
+        $cityDiff.ReferenceValue | Should -Be 'New York'
+        $cityDiff.DifferenceValue | Should -Be 'Los Angeles'
+        $cityDiff.SideIndicator | Should -Be '<>'
+
+        $prop1Diff = $result | Where-Object { $_.Name -eq 'Property1' }
+        $prop1Diff.ReferenceValue | Should -Be 'Value1'
+        $prop1Diff.DifferenceValue | Should -BeNullOrEmpty
+        $prop1Diff.SideIndicator | Should -Be '<='
+
+        $prop2Diff = $result | Where-Object { $_.Name -eq 'Property2' }
+        $prop2Diff.ReferenceValue | Should -BeNullOrEmpty
+        $prop2Diff.DifferenceValue | Should -Be 'Value2'
+        $prop2Diff.SideIndicator | Should -Be '=>'
+    }
+    It 'compares two objects and includes equal properties' {
+        $result = Compare-ObjectProperty -ReferenceObject $obj1 -DifferenceObject $obj2 -IncludeEqual
+        $result | Should -Not -BeNullOrEmpty
+        $result.Count | Should -Be 5
+
+        $nameDiff = $result | Where-Object { $_.Name -eq 'Name' }
+        $nameDiff.ReferenceValue | Should -Be 'Alice'
+        $nameDiff.DifferenceValue | Should -Be 'Alice'
+        $nameDiff.SideIndicator | Should -Be '=='
+    }
+    It 'compares two objects with specified property list' {
+        $result = Compare-ObjectProperty -ReferenceObject $obj1 -DifferenceObject $obj2 -PropertyList @('Name', 'Age')
+        $result | Should -Not -BeNullOrEmpty
+        $result.Count | Should -Be 1 -Because 'only Age is different in the specified property list'
+
+        $result.Name | Should -Not -Contain 'City' -Because 'City is not in the specified property list'
+        $result.Name | Should -Not -Contain 'Name' -Because 'Name is equal and not included without -IncludeEqual'
+
+        $ageDiff = $result | Where-Object { $_.Name -eq 'Age' }
+        $ageDiff.ReferenceValue | Should -Be 30
+        $ageDiff.DifferenceValue | Should -Be 32
+        $ageDiff.SideIndicator | Should -Be '<>'
+    }
+    It 'returns empty when no differences and no IncludeEqual' {
+        $obj3 = [PSCustomObject]@{ Name = "Bob"; Age = 25 }
+        $obj4 = [PSCustomObject]@{ Name = "Bob"; Age = 25 }
+
+        $result = Compare-ObjectProperty -ReferenceObject $obj3 -DifferenceObject $obj4
+        $result | Should -BeNullOrEmpty
+    }
+    It 'complex objects difference' {
+        $obj5 = [PSCustomObject]@{ Name = "Charlie"; Details = [PSCustomObject]@{ Height = 180; Weight = 75 } }
+        $obj6 = [PSCustomObject]@{ Name = "Charlie"; Details = [PSCustomObject]@{ Height = 182; Weight = 75 } }
+
+        $result = Compare-ObjectProperty -ReferenceObject $obj5 -DifferenceObject $obj6
+        $result | Should -Not -BeNullOrEmpty
+        $result.Count | Should -Be 1
+
+        $detailsDiff = $result | Where-Object { $_.Name -eq 'Details' }
+        $detailsDiff.ReferenceValue | Should -Be $obj5.Details
+        $detailsDiff.DifferenceValue | Should -Be $obj6.Details
+        $detailsDiff.SideIndicator | Should -Be '<>'
+    }
+    It 'complex objects are property equal' {
+        $obj7 = [PSCustomObject]@{ Name = "Diana"; Details = [PSCustomObject]@{ Height = 165; Weight = 60 } }
+        $obj8 = [PSCustomObject]@{ Name = "Diana"; Details = [PSCustomObject]@{ Height = 165; Weight = 60 } }
+
+        $result = Compare-ObjectProperty -ReferenceObject $obj7 -DifferenceObject $obj8 -IncludeEqual
+        $result | Should -Not -BeNullOrEmpty
+        $result.Count | Should -Be 2
+
+        $detailsDiff = $result | Where-Object { $_.Name -eq 'Details' }
+        $detailsDiff.ReferenceValue | Should -Be $obj7.Details
+        $detailsDiff.DifferenceValue | Should -Be $obj8.Details
+        $detailsDiff.SideIndicator | Should -Be '=='
+    }
+}

--- a/tests/Unit/Private/Compare-ObjectProperty.Tests.ps1
+++ b/tests/Unit/Private/Compare-ObjectProperty.Tests.ps1
@@ -1,9 +1,4 @@
 BeforeDiscovery {
-    $isNotConnected = $false
-    if ([string]::IsNullOrEmpty($uri) -or [string]::IsNullOrEmpty($apikey) -or $null -eq $credIdoit) {
-        Write-Warning -Message "You need to set the variables `$uri`, `$apikey`, and `$credIdoit` before running the tests."
-        $isNotConnected = $true
-    }
 }
 BeforeAll {
     $script:ModuleName = 'PSIdoitNG'
@@ -17,9 +12,6 @@ BeforeAll {
     $testRoot = Join-Path -Path (Get-SamplerAbsolutePath) -ChildPath 'tests'
     $testHelpersPath = Join-Path -Path $testRoot -ChildPath 'Unit\Helpers'
     $testIntegrationHelpersPath = Join-Path -Path $testRoot -ChildPath 'Integration\Helpers'
-    if (-not $IsNotConnected) {
-        Connect-Idoit -Uri $uri -Credential $credIdoit -ApiKey (ConvertFrom-SecureString $apikey -AsPlainText)
-    }
 }
 
 AfterAll {
@@ -27,7 +19,6 @@ AfterAll {
     $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
     $PSDefaultParameterValues.Remove('Should:ModuleName')
 
-    Disconnect-Idoit -ErrorAction SilentlyContinue
     Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
 }
 Describe 'Compare-ObjectProperty' {

--- a/tests/Unit/Public/ConvertFrom-MappingFile.tests.ps1
+++ b/tests/Unit/Public/ConvertFrom-MappingFile.tests.ps1
@@ -44,18 +44,23 @@ Describe 'ConvertFrom-MappingFile' {
             } -Parameters @{
                 Path = $PathMappingFile
             }
-            $result | Should -HaveCount 2
+            $result | Should -HaveCount 3
             #region person mapping
             $mapPerson = $result | Where-Object { $_.IdoitObjectType -eq 'C__OBJTYPE__PERSON' }
             $mapPerson.Name | Should -Be 'PersonMapped'
             $mapPerson.PSType | Should -Be 'Person'
             $mapPerson.IdoitObjectType | Should -Be 'C__OBJTYPE__PERSON'
-            $mapPerson.Mapping | Should -HaveCount 1
+            $mapPerson.Mapping | Should -HaveCount 2
             $cat0 = $mapPerson.Mapping[0]
             $cat0.Category | Should -Be 'C__CATS__PERSON'
             $cat0.PropertyList | Should -HaveCount 3
             $cat0.PropertyList.PSProperty | Should -Be 'Id','FirstName','LastName'
             $cat0.PropertyList.iAttribute | Should -Be 'Id','first_name','last_name'
+            $cat1 = $mapPerson.Mapping[1]
+            $cat1.Category | Should -Be 'C__CATG__GLOBAL'
+            $cat1.PropertyList | Should -HaveCount 2
+            $cat1.PropertyList.PSProperty | Should -Be 'CMDBStatus','CMDBStatusTitle'
+            $cat1.PropertyList.iAttribute | Should -Be 'cmdb_status','cmdb_status.title'
             #endregion person mapping
 
             #region server mapping

--- a/tests/Unit/Public/ConvertTo-IdoitObjectCategory.tests.ps1
+++ b/tests/Unit/Public/ConvertTo-IdoitObjectCategory.tests.ps1
@@ -36,7 +36,7 @@ Describe 'ConvertTo-IdoitObjectCategory' {
     Context 'Happy path' {
         It 'Converts mapped PERSON object to I-doit object structure' {
             $InputObject = [PSCustomObject]@{ FirstName = 'John'; LastName = 'Doe' }
-            $result = ConvertTo-IdoitObjectCategory -InputObject $InputObject -MappingName 'PersonMapped'
+            $result = ConvertTo-IdoitObjectCategory -InputObject $InputObject -MappingName 'PersonMapped' -IncludeProperty '*'
             $result | Should -BeOfType 'Hashtable'
             $result['C__CATS__PERSON']['first_name'] | Should -Be 'John'
             $result['C__CATS__PERSON']['last_name'] | Should -Be 'Doe'
@@ -46,14 +46,14 @@ Describe 'ConvertTo-IdoitObjectCategory' {
             $ObjId = 540
             $mappedObj = Get-IdoitMappedObject -ObjId $ObjId -MappingName 'ServerMapped'
             # Ignore warnings for nonconvertable action properties
-            $result = ConvertTo-IdoitObjectCategory -InputObject $mappedObj -MappingName 'ServerMapped' -WarningAction SilentlyContinue
+            $result = ConvertTo-IdoitObjectCategory -InputObject $mappedObj -MappingName 'ServerMapped' -WarningAction SilentlyContinue -IncludeProperty '*'
             $result | Should -BeOfType 'Hashtable'
             $result.C__CATG__GLOBAL['id'] | Should -Be $mappedObj.Id
             $result.C__CATG__GLOBAL['title'] | Should -Be $mappedObj.ComputerName
             $result.C__CATG__GLOBAL['description'] | Should -Be $mappedObj.Beschreibung
-            $result.C__CATG__MEMORY['capacity'].title | Should -Be $mappedObj.MemoryMBTitles
             $result.C__CATG__GLOBAL['tag'] | Should -Be $mappedObj.Tag
             $result.C__CATG__GLOBAL['tag'] | Should -BeOfType [System.Collections.IEnumerable]      # must be an array
+            $result.keys | Should -Be 'C__CATG__GLOBAL' -Because 'ServerMapepd memory category only has calculated properties, which are not converted for update.'
             # those who have an action defined in the mapping are not converted
         }
     }
@@ -68,14 +68,14 @@ Describe 'ConvertTo-IdoitObjectCategory' {
                 LastName = 'Doe';
                 UnknownProperty = 'Unknown'
             }
-            $result = ConvertTo-IdoitObjectCategory -InputObject $InputObject -MappingName 'PersonMapped'
+            $result = ConvertTo-IdoitObjectCategory -InputObject $InputObject -MappingName 'PersonMapped' -IncludeProperty '*'
             $result['C__CATS__PERSON']['first_name'] | Should -Be 'John'
             $result['C__CATS__PERSON']['last_name'] | Should -Be 'Doe'
             $result['C__CATS__PERSON'].Keys | Should -Not -Contain 'UnknownProperty'
         }
         It 'Excludes properties via ExcludeProperty' {
             $InputObject = [PSCustomObject]@{ FirstName = 'John'; LastName = 'Doe' }
-            $result = ConvertTo-IdoitObjectCategory -InputObject $InputObject -MappingName 'PersonMapped' -ExcludeProperty 'LastName'
+            $result = ConvertTo-IdoitObjectCategory -InputObject $InputObject -MappingName 'PersonMapped' -ExcludeProperty 'LastName' -IncludeProperty '*'
             $result['C__CATS__PERSON']['first_name'] | Should -Be 'John'
             $result['C__CATS__PERSON'].Keys | Should -Not -Contain 'last_name'
         }
@@ -91,7 +91,6 @@ Describe 'ConvertTo-IdoitObjectCategory' {
                 WarningVariable = 'warn'
             }
             $result = ConvertTo-IdoitObjectCategory @splatConvert
-            $warn | Should -Not -BeNullOrEmpty
             $result | Should -BeOfType 'Hashtable'
             $result.Keys | Should -BeNullOrEmpty
         }

--- a/tests/Unit/Public/Get-IdoitMappedObject.tests.ps1
+++ b/tests/Unit/Public/Get-IdoitMappedObject.tests.ps1
@@ -62,7 +62,7 @@ Describe 'Get-IdoitMappedObject' {
             } -Parameters @{
                 Path = $PathMappingFile
             }
-            $result | Should -HaveCount 2
+            $result | Should -HaveCount 3
             $thisTypeTested = $_.PSType
             $thisMapTested = $($result | Where-Object { $_.Name -eq $thisTypeTested })
 
@@ -115,7 +115,7 @@ Describe 'Get-IdoitMappedObject' {
             } -Parameters @{
                 Path = $PathMappingFile
             }
-            $result | Should -HaveCount 2
+            $result | Should -HaveCount 3
             $thisTypeTested = $_.Name
             $thisMapTested = $($result | Where-Object { $_.Name -eq $thisTypeTested })
 

--- a/tests/Unit/Public/Set-IdoItMappedObject.tests.ps1
+++ b/tests/Unit/Public/Set-IdoItMappedObject.tests.ps1
@@ -132,7 +132,7 @@ Describe 'Set-IdoitMappedObject' {
             # verify that a request was sent
             Assert-MockCalled -CommandName Invoke-RestMethod -ModuleName PSIdoitNG -ParameterFilter {
             (($body | ConvertFrom-Json).method) -eq 'cmdb.category.save'
-            } -Exactly 2 -Scope It
+            } -Exactly 1 -Scope It
         }
     }
     Context 'MyServer' {
@@ -211,7 +211,7 @@ Describe 'Set-IdoitMappedObject' {
                 (($body | ConvertFrom-Json).method) -eq 'cmdb.category.save'
             } -Exactly 1 -Scope It
         }
-        It 'Should Call Invoke-RestMethod 1 time (Update ComputerName); -ObjId not needed because already set' {
+        It 'Should Call Invoke-RestMethod (Update ComputerName); -ObjId not needed because already set' {
             $prevValues.ComputerName = 'This is a test'
             $prevValues.ObjId = $objId                  # assume it has been read with Get-IdoitMappedObject
             $result = Set-IdoitMappedObject -InputObject $prevValues -PropertyMap $map
@@ -221,7 +221,7 @@ Describe 'Set-IdoitMappedObject' {
                 (($body | ConvertFrom-Json).method) -eq 'cmdb.category.save'
             } -Exactly 1 -Scope It
         }
-        It 'Should Call Invoke-RestMethod 2 times (Update ComputerName and BeschreibungUndefined)' {
+        It 'Should Call Invoke-RestMethod (Update ComputerName and BeschreibungUndefined)' {
             $prevValues.ComputerName = 'This is a test'
             $prevValues.BeschreibungUndefined = 'This is a test'
             $result = Set-IdoitMappedObject -ObjId $objId -InputObject $prevValues -PropertyMap $map
@@ -229,7 +229,7 @@ Describe 'Set-IdoitMappedObject' {
             # verify that a request was sent
             Assert-MockCalled -CommandName Invoke-RestMethod -ModuleName PSIdoitNG -ParameterFilter {
                 (($body | ConvertFrom-Json).method) -eq 'cmdb.category.save'
-            } -Exactly 2 -Scope It
+            } -Exactly 1 -Scope It
         }
         It 'Should not call Invoke-RestMethod 1 times (Update ComputerName and BeschreibungUndefined, but exclude ComputerName)' {
             $prevValues.ComputerName = 'This is a test'


### PR DESCRIPTION
### Fixes
- New-IdoitObject accetps array of hashtables to allow several categories while creating
- add func ConvertTo-IdoitObjectCategory
- add (private) function Get-IdoitMappedObjectChange
- fix (#45 ) update (set) of dialog properties 

### Minor
- Reduce API calls when creating or updating a mapped object
- Add -AllowDuplicates to be able to create objects with name that already exists
- Better content check of config yaml
- Enhance test cases